### PR TITLE
Update 配置 H5 域名.md

### DIFF
--- a/mini/component/基础组件/开放组件/web-view/配置 H5 域名.md
+++ b/mini/component/基础组件/开放组件/web-view/配置 H5 域名.md
@@ -1,16 +1,16 @@
 
 # 简介
-使用 [web-view H5 页面承载组件](/mini/component/web-view) 时需要完成 H5 页面中所有域名地址（含静态资源地址，如图片、.js 文件地址等）配置，如 [my.createWebViewContext](https://opendocs.alipay.com/mini/api/webview-context)，此章节主要描述相关配置流程。配置过程中关于页面访问受限等 H5 问题请参见 [web-view 常见问题](https://opendocs.alipay.com/mini/component/mg7rvg) 。
+使用 [web-view H5 页面承载组件](/mini/component/web-view) 需要对要访问的 URL（主文档 URL、iframe 里的主文档 URL，以及后续跳转的主文档 URL）进行白名单配置，本文主要描述相关配置流程。web-view 相关的其他问题，可参考 [web-view 常见问题](https://opendocs.alipay.com/mini/component/mg7rvg) 。
 
 ## 使用限制
 
-- 域名添加或删除后仅对新版本生效，老版本仍使用修改前的域名配置。<br />
-- 已获取一个备案过的域名，该域名已经指向备案过的服务器。<br />
+- 只能添加备案过的域名，且该域名已经指向有效的、可控（能放置文件到域名根目录）的服务器。
+- **H5 域名配置变更后需要小程序发版，新的配置仅对新版小程序生效。**
 
 # 使用
 
 1. 登录 [支付宝开放平台控制台](https://openhome.alipay.com/platform/developerIndex.htm) 进入对应小程序开发设置页面。<br />![](http://mdn.alipayobjects.com/afts/img/A*oivsRKr3zg0AAAAAAAAAAAAAAa8wAA/original?bz=openpt_doc&t=O5PwuUsbhERIc5hNapxSJQAAAABkMK8AAAAA#align=left&display=inline&height=969&margin=%5Bobject%20Object%5D&originHeight=969&originWidth=1920&status=done&style=none&width=1920)<br />**说明：** 若是三方场景为小程序模板设置  **H5 域名配置**，需登录 **支付宝开放平台控制台** 进入对应小程序模板详情页面进行配置。<br />![](http://mdn.alipayobjects.com/afts/img/A*lykHR6bs4dgAAAAAAAAAAAAAAa8wAA/original?bz=openpt_doc&t=QyHdZN7tSpNVAgBgkejbfAAAAABkMK8AAAAA#align=left&display=inline&height=481&margin=%5Bobject%20Object%5D&originHeight=481&originWidth=1893&status=done&style=none&width=1893)<br />
 1. 点击 **H5 域名配置** 中的 **添加。**<br />![](http://mdn.alipayobjects.com/afts/img/A*r6W7TICDRz8AAAAAAAAAAAAAAa8wAA/original?bz=openpt_doc&t=xMk7zkeRTb8Cu7_qQB9ffAAAAABkMK8AAAAA#align=left&display=inline&height=969&margin=%5Bobject%20Object%5D&originHeight=969&originWidth=1920&status=done&style=none&width=1920)<br />
-1. 点击 **下载校验文件**，获取校验文件并放置在配置域名根目录下。<br />![](https://gw.alipayobjects.com/zos/skylark-tools/public/files/b9934c7290d57fb8cadf4a993867dd3b.png#align=left&display=inline&height=160&margin=%5Bobject%20Object%5D&originHeight=166&originWidth=772&status=done&style=none&width=746)<br />
-1. 输入域名地址，地址格式为 https://yourpath， 点击 **点击这里** 确认验证文件可以正常访问。如果配置正确，则校验通过。通过后点击 **确定**，即完成白名单配置。
-2. **注意：** 可键入 F12，进入 source，排查域名是否配置完整。<br />![](https://gw.alipayobjects.com/zos/skylark-tools/public/files/90ed12f210a4c29f96181d4e4a8fa48a.png#align=left&display=inline&height=101&margin=%5Bobject%20Object%5D&originHeight=202&originWidth=396&status=done&style=none&width=198)<br />
+1. 点击 **下载校验文件**，获取校验文件并放置在配置域名根目录下。nginx 的域名根目录可从配置文件中看到，如下图示例：<br />![](https://gw.alipayobjects.com/zos/skylark-tools/public/files/b9934c7290d57fb8cadf4a993867dd3b.png#align=left&display=inline&height=160&margin=%5Bobject%20Object%5D&originHeight=166&originWidth=772&status=done&style=none&width=746)<br />
+1. 输入域名地址，格式为 https://your-domain-name， 点击 **点击这里** 确认验证文件可以正常访问。如果配置正确，则校验通过。通过后点击 **确定**，即完成白名单配置。
+1. **注意：** 可使用 chrome 打开目标 H5 页，按 F12 键，进入 source 面板查看页面用到的相关域名（如不能区分哪些是主文档/iframe主文档域名，可以全都加上）**。如果页面还有后续跳转、可能涉及到不同域名，请确保将后续页面相关域名也加入配置** <br />![](https://gw.alipayobjects.com/zos/skylark-tools/public/files/90ed12f210a4c29f96181d4e4a8fa48a.png#align=left&display=inline&height=101&margin=%5Bobject%20Object%5D&originHeight=202&originWidth=396&status=done&style=none&width=198)<br />


### PR DESCRIPTION
1，更新简介，纠正需要添加所有资源域名的错误说法
2，更新使用限制，补充需要发版的说明替代原来的只对新版生效的不完整说法
3，更正域名地址格式（yourpath 改为 your-domain-name），避免误导
4，补充强调后续跳转页面也需要加白