### PR TITLE
Update my.openDocument.md

### DIFF
--- a/mini/api/基础API/文件/my.openDocument.md
+++ b/mini/api/基础API/文件/my.openDocument.md
@@ -56,7 +56,7 @@ Object 类型，属性如下：
 
 # Bug & Tips
 
-- 当前 Android 客户端中 my.openDocument 打开 PDF 预览不支持含有图片图层重叠的 PDF 显示，可以直接使用图片形式的 PDF。
+- Android：暂不支持显示 PDF 的签名。
 - iOS: 10.2.60之前的版本不支持[本地缓存文件](https://opendocs.alipay.com/mini/03dt4s#%E6%9C%AC%E5%9C%B0%E7%BC%93%E5%AD%98%E6%96%87%E4%BB%B6)。
 - Android: 10.2.60之前的版本不支持[本地用户文件](https://opendocs.alipay.com/mini/03dt4s#%E6%9C%AC%E5%9C%B0%E7%94%A8%E6%88%B7%E6%96%87%E4%BB%B6)。
 - iOS: 通过[my.downloadFile](https://opendocs.alipay.com/mini/api/xr054r)获取的本地临时文件路径可能因为下载的文件头信息设置不规范进而打开失败(由于系统原因)。可通过将本地临时文件保存为本地用户文件（指定`filePath`值带`pdf`后缀）来规避，例如：

--- a/mini/api/基础API/文件/my.openDocument.md
+++ b/mini/api/基础API/文件/my.openDocument.md
@@ -4,7 +4,7 @@
 
 ## 使用限制
 
-- 基础库 [1.15.0 ](https://opendocs.alipay.com/mini/framework/lib)或更高版本，支付宝客户端 10.1.60 或更高版本，若版本较低，建议采取 [兼容处理](/mini/framework/compatibility)。
+- 基础库 [1.15.0 ](https://opendocs.alipay.com/mini/framework/lib) 或更高版本，支付宝客户端 10.1.60 或更高版本，若版本较低，建议采取 [兼容处理](https://opendocs.alipay.com/mini/framework/compatibility)。
 - my.openDocument 只支持在真机上测试，无法在 IDE 上调试。
 - 此 API 支持个人支付宝小程序、企业支付宝小程序使用。
 
@@ -56,6 +56,7 @@ Object 类型，属性如下：
 
 # Bug & Tips
 
+- 当前 Android 客户端中 my.openDocument 打开 PDF 预览不支持含有图片图层重叠的 PDF 显示，可以直接使用图片形式的 PDF。
 - iOS: 10.2.60之前的版本不支持[本地缓存文件](https://opendocs.alipay.com/mini/03dt4s#%E6%9C%AC%E5%9C%B0%E7%BC%93%E5%AD%98%E6%96%87%E4%BB%B6)。
 - Android: 10.2.60之前的版本不支持[本地用户文件](https://opendocs.alipay.com/mini/03dt4s#%E6%9C%AC%E5%9C%B0%E7%94%A8%E6%88%B7%E6%96%87%E4%BB%B6)。
 - iOS: 通过[my.downloadFile](https://opendocs.alipay.com/mini/api/xr054r)获取的本地临时文件路径可能因为下载的文件头信息设置不规范进而打开失败(由于系统原因)。可通过将本地临时文件保存为本地用户文件（指定`filePath`值带`pdf`后缀）来规避，例如：


### PR DESCRIPTION
增加说明：当前 Android 客户端中 my.openDocument 打开 PDF 预览不支持含有图片图层重叠的 PDF 显示，可以直接使用图片形式的 PDF。