### PR TITLE
fix: 不支持插件间互相引用，删除文档描述不当的内容

### DIFF
--- a/mini/plugin/插件开发与发布/插件开发.md
+++ b/mini/plugin/插件开发与发布/插件开发.md
@@ -213,31 +213,6 @@ if (my.canIUse('plugin.requireMiniProgram')) {
     }
 ```
 
-## 插件间互相调用
-
-插件不支持直接使用其他插件。如果小程序引用了多个插件，插件之间可以互相调用但不支持互相跳转，如实在需要跳转操作，请参见 [插件场景下各种跳转方式指南](https://opendocs.alipay.com/mini/plugin/plugin-development#%E6%8F%92%E4%BB%B6%E5%9C%BA%E6%99%AF%E4%B8%8B%E5%90%84%E7%A7%8D%E8%B7%B3%E8%BD%AC%E6%96%B9%E5%BC%8F%E6%8C%87%E5%8D%97)。
-
-例如，第三方小程序中的 app.json ：
-
-```json
-{
-  "plugins": {
-    "pluginOne": {
-      "version": "1.0.0",
-      "provider": "2019081209098989"
-    },
-    "pluginTwo": {
-      "version": "1.0.0",
-      "provider": "2019081209091212"
-    }
-  }
-}
-```
-
-上方示例中，第三方小程序通过 app.json 引用了两个插件，那么插件 pluginOne 可以通过：
-
-[requirePlugin](https://opendocs.alipay.com/mini/plugin/plugin-usage)('pluginTwo') 的方式来引用插件 pluginTwo 暴露的 js 接口。
-
 ## getCurrentPages
 
 getCurrentPages 用于返回当前页面栈，默认返回过程中存在如下限制：


### PR DESCRIPTION
支付宝小程序不支持插件间互相引用，文档描述不当